### PR TITLE
Send static build index.html if no route match

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const bodyParser = require('body-parser')
 const app = express()
 const cors = require('cors')
 const mongoose = require('mongoose')
+const path = require('path')
 
 //Routrers
 const usersRouter = require('./controllers/users')
@@ -49,8 +50,16 @@ app.use(`${apiUrl}/events`, eventsRouter)
 app.use(`${apiUrl}/login`, loginRouter)
 app.use(`${apiUrl}/tokenCheck`, tokenCheckRouter)
 
+if (process.env.NODE_ENV === 'production') {
+  const FRONTEND_PATH = path.join(__dirname, 'build')
+  app.use(express.static(FRONTEND_PATH))// Handle React routing, return all requests to React app
 
-app.use(middleware.unknownEndpoint)
+  // Serve any static files
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(FRONTEND_PATH, 'index.html'))
+  })
+}
+
 app.use(middleware.errorHandler)
 
 module.exports = app

--- a/utils/middleware.js
+++ b/utils/middleware.js
@@ -8,11 +8,6 @@ const requestLogger = (request, response, next) => {
   next()
 }
 
-
-const unknownEndpoint = (req, res) => {
-  res.status(404).send({ error: 'unknown endpoint' })
-}
-
 const errorHandler = (error, req, res, next) => {
   console.error(error.message)
   if (error.name === 'CastError' && error.kind === 'ObjectId') {
@@ -30,6 +25,5 @@ const errorHandler = (error, req, res, next) => {
 
 module.exports = {
   requestLogger,
-  unknownEndpoint,
   errorHandler
 }


### PR DESCRIPTION
- Serve static build if no route match on frontend, fixes react-router issue where the page cannot be found after reload.
- Remove 404 message from backend, since now it will never be triggered.
  - Could be handled on the frontend: make a route for when there is no match.